### PR TITLE
Allow app_test as entry point

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -18,7 +18,7 @@ DATA_PATH=./data
 # Nginx configuration customization
 NGINX_PROJECT_ROOT=/application/web
 NGINX_ENTRY_POINT_FILE=app_dev.php
-NGINX_ALLOWED_FILES="app|app_dev|config"
+NGINX_ALLOWED_FILES="app|app_dev|app_test|config"
 
 # docker-sync volume name
 SYNC_NAME=application


### PR DESCRIPTION
End to end tests like we do with Behat,
should target the app_test.php entry point of
Symfony apps.

This commit allows nginx to use
app_test.php as an entry point.